### PR TITLE
add argparse to read the input file

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+requests

--- a/xfpm.py
+++ b/xfpm.py
@@ -37,6 +37,12 @@ def get_args():
         default=None)
 
     parser.add_argument(
+        "-d",
+        "--debug",
+        help="activate the scripts internal debugger",
+        action="store_true")
+
+    parser.add_argument(
         "-t",
         "--test",
         help="constrain a test run to 125 lines output",
@@ -60,7 +66,7 @@ def check_url_exists(url):
 
 
 # infile = "fcog_readme_20240204.md" # version from 2024-02-04 -- copy of https://github.com/Beliavsky/Fortran-code-on-GitHub/blob/main/README.md
-def file_reader(infile="", test=False):
+def file_reader(infile="", debug=False, test=False):
     """work on the input file"""
 
     # allow a constrained test run:
@@ -69,7 +75,7 @@ def file_reader(infile="", test=False):
     else:
         max_lines = 10**6
 
-    debug = False
+#    debug = False
 #with open(infile, "r", encoding="utf-8") as fp:
 
     # for i, text in enumerate(fp):
@@ -105,11 +111,12 @@ def main():
 
     args = get_args()
     infile = args.file
+    debugger_level = args.debug
     test_level = args.test
 
-    file_reader(infile, test_level)
+    file_reader(infile, debugger_level, test_level)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()
 # print("time elapsed (s):", "%0.2f"%(time.time() - t0))

--- a/xfpm.py
+++ b/xfpm.py
@@ -32,7 +32,7 @@ def get_args():
 
     parser.add_argument(
         "file",
-        help="said README.me file",
+        help="said README.md file",
         metavar="FILE",
         type=argparse.FileType("rt", encoding="utf-8"),
         default=None,

--- a/xfpm.py
+++ b/xfpm.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 
 import argparse
 import os

--- a/xfpm.py
+++ b/xfpm.py
@@ -17,7 +17,7 @@ import requests
 
 os.environ['PYTHONIOENCODING'] = 'utf-8'
 
-t0 = time.time()
+# t0 = time.time()
 
 
 def get_args():
@@ -118,8 +118,9 @@ def main():
     debugger_level = args.debug
     test_level = args.test
 
+    t0 = time.time()
     file_reader(infile, debugger_level, test_level)
-
+    print("time elapsed (s):", "%0.2f"%(time.time() - t0))
 
 if __name__ == "__main__":
     main()

--- a/xfpm.py
+++ b/xfpm.py
@@ -75,11 +75,7 @@ def check_url_exists(url):
 def file_reader(infile="", debug=False, test=False):
     """iterate on the input file till reaching the threshold"""
 
-    # allow a constrained test run:
-    if test:
-        max_lines = 125
-    else:
-        max_lines = 10**6
+    max_lines = 125 if test else 10**6  # allow a constrained test run
 
     for i, text in enumerate(infile):
         if i > max_lines:

--- a/xfpm.py
+++ b/xfpm.py
@@ -54,6 +54,7 @@ def get_args():
 
 
 def check_url_exists(url):
+    """check accessibility of queried url"""
     try:
         # Make a HEAD request to get headers and avoid downloading the content
         response = requests.head(url, allow_redirects=True)

--- a/xfpm.py
+++ b/xfpm.py
@@ -1,5 +1,14 @@
 #!/usr/bin/env python3
 
+"""
+name     : xfpm.py
+source   : https://github.com/Beliavsky/Fortran-packages-list
+author   : Beliavsky, Norwid Behrnd
+license  : MIT
+last edit: 2024-02-27
+purpose  : report projects that can be built with the Fortran Package Manager
+"""
+
 import argparse
 import os
 os.environ['PYTHONIOENCODING'] = 'utf-8'

--- a/xfpm.py
+++ b/xfpm.py
@@ -11,10 +11,12 @@ purpose  : report projects that can be built with the Fortran Package Manager
 
 import argparse
 import os
-os.environ['PYTHONIOENCODING'] = 'utf-8'
 import re
 import requests
 import time
+
+os.environ['PYTHONIOENCODING'] = 'utf-8'
+
 t0 = time.time()
 
 

--- a/xfpm.py
+++ b/xfpm.py
@@ -17,8 +17,6 @@ import requests
 
 os.environ['PYTHONIOENCODING'] = 'utf-8'
 
-# t0 = time.time()
-
 
 def get_args():
     """get the command-line arguments"""
@@ -78,10 +76,6 @@ def file_reader(infile="", debug=False, test=False):
     else:
         max_lines = 10**6
 
-#    debug = False
-#with open(infile, "r", encoding="utf-8") as fp:
-
-    # for i, text in enumerate(fp):
     for i, text in enumerate(infile):
         if i > max_lines:
             break
@@ -120,9 +114,7 @@ def main():
 
     t0 = time.time()
     file_reader(infile, debugger_level, test_level)
-#     print("time elapsed (s):", "%0.2f"%(time.time() - t0))
     print(f"time elapsed (s): {(time.time() - t0):.2f}")
 
 if __name__ == "__main__":
     main()
-# print("time elapsed (s):", "%0.2f"%(time.time() - t0))

--- a/xfpm.py
+++ b/xfpm.py
@@ -1,9 +1,33 @@
+
+import argparse
 import os
 os.environ['PYTHONIOENCODING'] = 'utf-8'
 import re
 import requests
 import time
 t0 = time.time()
+
+
+def get_args():
+    """get the command-line arguments"""
+
+    parser = argparse.ArgumentParser(
+        description="""List projects, organized by topic, that can be built with
+        the Fortran Package Manager.  For this, file README.md of project
+        'Directory of Fortran codes on GitHub' curated by Beliavsky et al. (see
+        https://github.com/Beliavsky/Fortran-code-on-GitHub) is processed as
+        input for this script.""",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+
+    parser.add_argument(
+        "file",
+        help="said README.me file",
+        metavar="FILE",
+        type=argparse.FileType("rt", encoding="utf-8"),
+        default=None)
+
+    return parser.parse_args()
+
 
 def check_url_exists(url):
     try:
@@ -18,11 +42,16 @@ def check_url_exists(url):
         # Handle exceptions like network errors, invalid URLs, etc.
         return False, str(e)
 
-infile = "fcog_readme_20240204.md" # version from 2024-02-04 -- copy of https://github.com/Beliavsky/Fortran-code-on-GitHub/blob/main/README.md
-max_lines = 10**6
-debug = False
-with open(infile, "r", encoding="utf-8") as fp:
-    for i, text in enumerate(fp):
+
+# infile = "fcog_readme_20240204.md" # version from 2024-02-04 -- copy of https://github.com/Beliavsky/Fortran-code-on-GitHub/blob/main/README.md
+def file_reader(infile=""):
+    """work on the input file"""
+    max_lines = 10**6
+    debug = False
+#with open(infile, "r", encoding="utf-8") as fp:
+
+    # for i, text in enumerate(fp):
+    for i, text in enumerate(infile):
         if i > max_lines:
             break
         if text.startswith("*") or text.startswith("##"): # category marker
@@ -47,4 +76,17 @@ with open(infile, "r", encoding="utf-8") as fp:
                     print("An encoding error occurred: ", e)
                 if debug:
                     print(fpm_link)
-print("time elapsed (s):", "%0.2f"%(time.time() - t0))
+
+
+def main():
+    """join the functionalities"""
+
+    args = get_args()
+    infile = args.file
+
+    file_reader(infile)
+
+
+if __name__ == '__main__':
+    main()
+# print("time elapsed (s):", "%0.2f"%(time.time() - t0))

--- a/xfpm.py
+++ b/xfpm.py
@@ -67,7 +67,6 @@ def check_url_exists(url):
         return False, str(e)
 
 
-# infile = "fcog_readme_20240204.md" # version from 2024-02-04 -- copy of https://github.com/Beliavsky/Fortran-code-on-GitHub/blob/main/README.md
 def file_reader(infile="", debug=False, test=False):
     """work on the input file"""
 
@@ -102,7 +101,8 @@ def file_reader(infile="", debug=False, test=False):
                 try:
                     print(text)
                 except UnicodeEncodeError as e:
-                    # Handle the error: for example, print a placeholder text or encode the text in 'utf-8' and print
+                    # Handle the error: for example, print a placeholder text or
+                    # encode the text in 'utf-8' and print
                     print("An encoding error occurred: ", e)
                 if debug:
                     print(fpm_link)

--- a/xfpm.py
+++ b/xfpm.py
@@ -5,7 +5,7 @@ name     : xfpm.py
 source   : https://github.com/Beliavsky/Fortran-packages-list
 author   : Beliavsky, Norwid Behrnd
 license  : MIT
-last edit: 2024-03-12
+last edit: [2024-03-28 Thu]
 purpose  : report projects that can be built with the Fortran Package Manager
 """
 
@@ -73,7 +73,7 @@ def check_url_exists(url):
 
 
 def file_reader(infile="", debug=False, test=False):
-    """work on the input file"""
+    """iterate on the input file till reaching the threshold"""
 
     # allow a constrained test run:
     if test:
@@ -84,29 +84,34 @@ def file_reader(infile="", debug=False, test=False):
     for i, text in enumerate(infile):
         if i > max_lines:
             break
-        if text.startswith("*") or text.startswith("##"):  # category marker
-            print(text)
-            continue
-        # text in parentheses after first after first set of brackets
-        match = re.search(r"\[.*?\]\((.*?)\)", text)
-        # Extract the match, if it exists
-        extracted_address = match.group(1) if match else None
-        if extracted_address:
+        checker(text, debug, i)
+
+
+def checker(text, debug=False, i=1):
+    """extract the address, report if fpm.toml file is present"""
+    if text.startswith("*") or text.startswith("##"):  # category marker
+        print(text)
+        # continue
+    # text in parentheses after first after first set of brackets
+    match = re.search(r"\[.*?\]\((.*?)\)", text)
+    # Extract the match, if it exists
+    extracted_address = match.group(1) if match else None
+    if extracted_address:
+        if debug:
+            print("\n", i)
+            print(text.strip())
+            print(f"url: {extracted_address}")
+        fpm_link = extracted_address + "/blob/master/fpm.toml"
+        exists, status_or_error = check_url_exists(fpm_link)
+        if exists:
+            try:
+                print(text)
+            except UnicodeEncodeError as e:
+                # Handle the error: for example, print a placeholder text or
+                # encode the text in 'utf-8' and print
+                print("An encoding error occurred: ", e)
             if debug:
-                print("\n", i)
-                print(text.strip())
-                print(f"url: {extracted_address}")
-            fpm_link = extracted_address + "/blob/master/fpm.toml"
-            exists, status_or_error = check_url_exists(fpm_link)
-            if exists:
-                try:
-                    print(text)
-                except UnicodeEncodeError as e:
-                    # Handle the error: for example, print a placeholder text or
-                    # encode the text in 'utf-8' and print
-                    print("An encoding error occurred: ", e)
-                if debug:
-                    print(fpm_link)
+                print(fpm_link)
 
 
 def main():

--- a/xfpm.py
+++ b/xfpm.py
@@ -15,7 +15,7 @@ import re
 import time
 import requests
 
-os.environ['PYTHONIOENCODING'] = 'utf-8'
+os.environ["PYTHONIOENCODING"] = "utf-8"
 
 
 def get_args():
@@ -27,26 +27,30 @@ def get_args():
         'Directory of Fortran codes on GitHub' curated by Beliavsky et al. (see
         https://github.com/Beliavsky/Fortran-code-on-GitHub) is processed as
         input for this script.""",
-        formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
 
     parser.add_argument(
         "file",
         help="said README.me file",
         metavar="FILE",
         type=argparse.FileType("rt", encoding="utf-8"),
-        default=None)
+        default=None,
+    )
 
     parser.add_argument(
         "-d",
         "--debug",
         help="activate the scripts internal debugger",
-        action="store_true")
+        action="store_true",
+    )
 
     parser.add_argument(
         "-t",
         "--test",
         help="constrain a test run to 125 lines output",
-        action="store_true")
+        action="store_true",
+    )
 
     return parser.parse_args()
 
@@ -79,11 +83,11 @@ def file_reader(infile="", debug=False, test=False):
     for i, text in enumerate(infile):
         if i > max_lines:
             break
-        if text.startswith("*") or text.startswith("##"): # category marker
+        if text.startswith("*") or text.startswith("##"):  # category marker
             print(text)
             continue
         # text in parentheses after first after first set of brackets
-        match = re.search(r'\[.*?\]\((.*?)\)', text) 
+        match = re.search(r"\[.*?\]\((.*?)\)", text)
         # Extract the match, if it exists
         extracted_text = match.group(1) if match else None
         if extracted_text:
@@ -115,6 +119,7 @@ def main():
     t0 = time.time()
     file_reader(infile, debugger_level, test_level)
     print(f"time elapsed (s): {(time.time() - t0):.2f}")
+
 
 if __name__ == "__main__":
     main()

--- a/xfpm.py
+++ b/xfpm.py
@@ -36,6 +36,12 @@ def get_args():
         type=argparse.FileType("rt", encoding="utf-8"),
         default=None)
 
+    parser.add_argument(
+        "-t",
+        "--test",
+        help="constrain a test run to 125 lines output",
+        action="store_true")
+
     return parser.parse_args()
 
 
@@ -54,9 +60,15 @@ def check_url_exists(url):
 
 
 # infile = "fcog_readme_20240204.md" # version from 2024-02-04 -- copy of https://github.com/Beliavsky/Fortran-code-on-GitHub/blob/main/README.md
-def file_reader(infile=""):
+def file_reader(infile="", test=False):
     """work on the input file"""
-    max_lines = 10**6
+
+    # allow a constrained test run:
+    if test:
+        max_lines = 125
+    else:
+        max_lines = 10**6
+
     debug = False
 #with open(infile, "r", encoding="utf-8") as fp:
 
@@ -93,8 +105,9 @@ def main():
 
     args = get_args()
     infile = args.file
+    test_level = args.test
 
-    file_reader(infile)
+    file_reader(infile, test_level)
 
 
 if __name__ == '__main__':

--- a/xfpm.py
+++ b/xfpm.py
@@ -12,8 +12,8 @@ purpose  : report projects that can be built with the Fortran Package Manager
 import argparse
 import os
 import re
-import requests
 import time
+import requests
 
 os.environ['PYTHONIOENCODING'] = 'utf-8'
 
@@ -57,7 +57,8 @@ def check_url_exists(url):
     """check accessibility of queried url"""
     try:
         # Make a HEAD request to get headers and avoid downloading the content
-        response = requests.head(url, allow_redirects=True)
+        # https://stackoverflow.com/questions/46016004/how-to-handle-timeout-error-in-request-headurl
+        response = requests.head(url, allow_redirects=True, timeout=5)
         # Check if the response status code is in the range of 200-299 (success)
         if response.status_code in range(200, 300):
             return True, response.status_code

--- a/xfpm.py
+++ b/xfpm.py
@@ -120,7 +120,8 @@ def main():
 
     t0 = time.time()
     file_reader(infile, debugger_level, test_level)
-    print("time elapsed (s):", "%0.2f"%(time.time() - t0))
+#     print("time elapsed (s):", "%0.2f"%(time.time() - t0))
+    print(f"time elapsed (s): {(time.time() - t0):.2f}")
 
 if __name__ == "__main__":
     main()

--- a/xfpm.py
+++ b/xfpm.py
@@ -5,7 +5,7 @@ name     : xfpm.py
 source   : https://github.com/Beliavsky/Fortran-packages-list
 author   : Beliavsky, Norwid Behrnd
 license  : MIT
-last edit: 2024-03-01
+last edit: 2024-03-12
 purpose  : report projects that can be built with the Fortran Package Manager
 """
 
@@ -90,13 +90,13 @@ def file_reader(infile="", debug=False, test=False):
         # text in parentheses after first after first set of brackets
         match = re.search(r"\[.*?\]\((.*?)\)", text)
         # Extract the match, if it exists
-        extracted_text = match.group(1) if match else None
-        if extracted_text:
+        extracted_address = match.group(1) if match else None
+        if extracted_address:
             if debug:
                 print("\n", i)
                 print(text.strip())
-                print(extracted_text)
-            fpm_link = extracted_text + "/blob/master/fpm.toml"
+                print(f"url: {extracted_address}")
+            fpm_link = extracted_address + "/blob/master/fpm.toml"
             exists, status_or_error = check_url_exists(fpm_link)
             if exists:
                 try:

--- a/xfpm.py
+++ b/xfpm.py
@@ -5,7 +5,7 @@ name     : xfpm.py
 source   : https://github.com/Beliavsky/Fortran-packages-list
 author   : Beliavsky, Norwid Behrnd
 license  : MIT
-last edit: 2024-02-27
+last edit: 2024-03-01
 purpose  : report projects that can be built with the Fortran Package Manager
 """
 
@@ -13,6 +13,7 @@ import argparse
 import os
 import re
 import time
+
 import requests
 
 os.environ["PYTHONIOENCODING"] = "utf-8"

--- a/xfpm_c.py
+++ b/xfpm_c.py
@@ -100,19 +100,14 @@ def file_reader(infile="", debug=False, test=False):
     return raw_data
 
 
-#def checker(text, debug=False, i=1):
 def checker(text, debug=False):
     """extract the address, report if fpm.toml file is present"""
-#    if text.startswith("*") or text.startswith("##"):  # category marker
-#        print(text)
-
     # text in parentheses after first after first set of brackets
     match = re.search(r"\[.*?\]\((.*?)\)", text)
     # Extract the match, if it exists
     extracted_address = match.group(1) if match else None
     if extracted_address:
         if debug:
-#            print("\n", i)
             print("".join([text.strip(), "\n"]))
             print(f"url: {extracted_address}")
         fpm_link = extracted_address + "/blob/master/fpm.toml"

--- a/xfpm_c.py
+++ b/xfpm_c.py
@@ -11,12 +11,12 @@ purpose  : report projects that can be built with the Fortran Package Manager
 
 import argparse
 import os
-# import re
+import re
 import time
-# from urllib3.util import Retry
+from urllib3.util import Retry
 
-# import requests
-# from requests.adapters import HTTPAdapter
+import requests
+from requests.adapters import HTTPAdapter
 
 os.environ["PYTHONIOENCODING"] = "utf-8"
 
@@ -58,27 +58,27 @@ def get_args():
     return parser.parse_args()
 
 
-#def check_url_exists(url, max_redirects=20, max_retries=5):
-#    """check accessibility of queried url"""
+def check_url_exists(url, max_redirects=20, max_retries=5):
+    """check accessibility of queried url"""
 
-#    session = requests.Session()
-#    retries = Retry(
-#        total=max_retries, backoff_factor=1.1, status_forcelist=[500, 502, 503, 504]
-#    )
-#    session.mount("https://", HTTPAdapter(max_retries=retries))
+    session = requests.Session()
+    retries = Retry(
+        total=max_retries, backoff_factor=1.1, status_forcelist=[500, 502, 503, 504]
+    )
+    session.mount("https://", HTTPAdapter(max_retries=retries))
 
-#    try:
-#        # Make a HEAD request to get headers and avoid downloading the content
-#        # https://stackoverflow.com/questions/46016004/how-to-handle-timeout-error-in-request-headurl
-#        response = requests.head(url, allow_redirects=True, timeout=5)
-#        # Check if the response status code is in the range of 200-299 (success)
-#        if response.status_code in range(200, 300):
-#            return True, response.status_code
-#        else:
-#            return False, response.status_code
-#    except requests.RequestException as e:
-#        # Handle exceptions like network errors, invalid URLs, etc.
-#        return False, str(e)
+    try:
+        # Make a HEAD request to get headers and avoid downloading the content
+        # https://stackoverflow.com/questions/46016004/how-to-handle-timeout-error-in-request-headurl
+        response = requests.head(url, allow_redirects=True, timeout=5)
+        # Check if the response status code is in the range of 200-299 (success)
+        if response.status_code in range(200, 300):
+            return True, response.status_code
+        else:
+            return False, response.status_code
+    except requests.RequestException as e:
+        # Handle exceptions like network errors, invalid URLs, etc.
+        return False, str(e)
 
 
 def file_reader(infile="", debug=False, test=False):
@@ -101,30 +101,31 @@ def file_reader(infile="", debug=False, test=False):
 
 
 #def checker(text, debug=False, i=1):
-#    """extract the address, report if fpm.toml file is present"""
+def checker(text, debug=False):
+    """extract the address, report if fpm.toml file is present"""
 #    if text.startswith("*") or text.startswith("##"):  # category marker
 #        print(text)
 
-#    # text in parentheses after first after first set of brackets
-#    match = re.search(r"\[.*?\]\((.*?)\)", text)
-#    # Extract the match, if it exists
-#    extracted_address = match.group(1) if match else None
-#    if extracted_address:
-#        if debug:
+    # text in parentheses after first after first set of brackets
+    match = re.search(r"\[.*?\]\((.*?)\)", text)
+    # Extract the match, if it exists
+    extracted_address = match.group(1) if match else None
+    if extracted_address:
+        if debug:
 #            print("\n", i)
-#            print(text.strip())
-#            print(f"url: {extracted_address}")
-#        fpm_link = extracted_address + "/blob/master/fpm.toml"
-#        exists, status_or_error = check_url_exists(fpm_link)
-#        if exists:
-#            try:
-#                print(text)
-#            except UnicodeEncodeError as e:
-#                # Handle the error: for example, print a placeholder text or
-#                # encode the text in 'utf-8' and print
-#                print("An encoding error occurred: ", e)
-#            if debug:
-#                print(fpm_link)
+            print("".join([text.strip(), "\n"]))
+            print(f"url: {extracted_address}")
+        fpm_link = extracted_address + "/blob/master/fpm.toml"
+        exists, status_or_error = check_url_exists(fpm_link)
+        if exists:
+            try:
+                print("".join([text, "\n"]))
+            except UnicodeEncodeError as e:
+                # Handle the error: for example, print a placeholder text or
+                # encode the text in 'utf-8' and print
+                print("An encoding error occurred: ", e)
+            if debug:
+                print(fpm_link)
 
 
 def triage_lines(raw_data, debug=False):
@@ -154,7 +155,8 @@ def triage_lines(raw_data, debug=False):
                         print(f"{len(intermediate_register)} entries to check")
 
                     for entry in intermediate_register:
-                        print("".join([entry, "\n"]))
+#                        print("".join([entry, "\n"]))
+                        checker(entry, debug)
                     intermediate_register = []
                 previous_section_title = line
 
@@ -167,8 +169,8 @@ def triage_lines(raw_data, debug=False):
                 print(f"{len(intermediate_register)} entries to check")
 
             for entry in intermediate_register:
-                print("".join([entry, "\n"]))
-
+#                print("".join([entry, "\n"]))
+                checker(entry, debug)
 
 
 def main():

--- a/xfpm_c.py
+++ b/xfpm_c.py
@@ -118,7 +118,8 @@ def checker(text, debug=False):
         exists, status_or_error = check_url_exists(fpm_link)
         if exists:
             try:
-                print("".join([text, "\n"]))
+                single_test = "".join([text, "\n"])
+                return single_test
             except UnicodeEncodeError as e:
                 # Handle the error: for example, print a placeholder text or
                 # encode the text in 'utf-8' and print
@@ -148,26 +149,38 @@ def triage_lines(raw_data, debug=False):
         if line.startswith("##"):
             if line.startswith("## Fortran code on GitHub") is False:
                 if intermediate_register:
-                    print("".join([previous_section_title, "\n"]))
 
                     if debug:
                         print(f"{len(intermediate_register)} entries to check")
 
+                    affirmative_tests = []
                     for entry in intermediate_register:
-                        checker(entry, debug)
+                        test = checker(entry, debug)
+                        if test is not None:
+                            affirmative_tests.append(test)
+                    if affirmative_tests:
+                        print("".join([previous_section_title, "\n"]))
+                        for entry in affirmative_tests:
+                            print(entry)
                     intermediate_register = []
+
                 previous_section_title = line
 
         # Equally report a section if a line about a project happens to be the
         # ultimate line of the raw_data read:
         if i == len(raw_data) - 1:
-            print("".join([previous_section_title, "\n"]))
-
             if debug:
                 print(f"{len(intermediate_register)} entries to check")
 
+            affirmative_tests = []
             for entry in intermediate_register:
-                checker(entry, debug)
+                test = checker(entry, debug)
+                if test is not None:
+                    affirmative_tests.append(test)
+            if affirmative_tests:
+                print("".join([previous_section_title, "\n"]))
+                for entry in affirmative_tests:
+                    print(entry)
 
 
 def main():

--- a/xfpm_c.py
+++ b/xfpm_c.py
@@ -97,6 +97,10 @@ def file_reader(infile="", debug=False, test=False):
         print(f"array_prior_test_condition: {array_prior_test_condition}")
         print(f"array_after_test_condition: {array_after_test_condition}")
 
+        pattern = re.compile("^\[")  # signature of project lines in raw_data
+        projects = list(filter(pattern.match, raw_data))
+        print(f"up to {len(projects)} projectes to consider\n")
+
     return raw_data
 
 
@@ -109,7 +113,7 @@ def checker(text, debug=False):
     if extracted_address:
         if debug:
             print("".join([text.strip(), "\n"]))
-            print(f"url: {extracted_address}")
+            print(f"url: {extracted_address}\n")
         fpm_link = extracted_address + "/blob/master/fpm.toml"
         exists, status_or_error = check_url_exists(fpm_link)
         if exists:
@@ -150,7 +154,6 @@ def triage_lines(raw_data, debug=False):
                         print(f"{len(intermediate_register)} entries to check")
 
                     for entry in intermediate_register:
-#                        print("".join([entry, "\n"]))
                         checker(entry, debug)
                     intermediate_register = []
                 previous_section_title = line
@@ -164,7 +167,6 @@ def triage_lines(raw_data, debug=False):
                 print(f"{len(intermediate_register)} entries to check")
 
             for entry in intermediate_register:
-#                print("".join([entry, "\n"]))
                 checker(entry, debug)
 
 

--- a/xfpm_c.py
+++ b/xfpm_c.py
@@ -5,14 +5,16 @@ name     : xfpm_c.py
 source   : https://github.com/Beliavsky/Fortran-packages-list
 author   : Beliavsky, Norwid Behrnd
 license  : MIT
-last edit: [2024-04-26 Fri]
+last edit: [2024-05-07 Tue]
 purpose  : report projects that can be built with the Fortran Package Manager
 """
 
 import argparse
+import datetime
 import os
 import re
-import time
+
+from time import perf_counter
 from urllib3.util import Retry
 
 import requests
@@ -99,7 +101,7 @@ def file_reader(infile="", debug=False, test=False):
 
         pattern = re.compile("^\[")  # signature of project lines in raw_data
         projects = list(filter(pattern.match, raw_data))
-        print(f"up to {len(projects)} projectes to consider\n")
+        print(f"up to {len(projects)} projects to consider\n")
 
     return raw_data
 
@@ -160,6 +162,7 @@ def triage_lines(raw_data, debug=False):
                             affirmative_tests.append(test)
                     if affirmative_tests:
                         print("".join([previous_section_title, "\n"]))
+                        affirmative_tests = sorted(affirmative_tests, key=str.casefold)
                         for entry in affirmative_tests:
                             print(entry)
                     intermediate_register = []
@@ -191,10 +194,13 @@ def main():
     debugger_level = args.debug
     test_level = args.test
 
-    t0 = time.time()
+    start = perf_counter()
     raw_data = file_reader(infile, debugger_level, test_level)
     triage_lines(raw_data, debugger_level)
-    print(f"time elapsed (s): {(time.time() - t0):.2f}")
+    end = perf_counter()
+
+    print(f"last update: {datetime.date.today()}")
+    print(f"time elapsed (s): {(end - start):.2f}")
 
 
 if __name__ == "__main__":

--- a/xfpm_c.py
+++ b/xfpm_c.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+
+"""
+name     : xfpm_c.py
+source   : https://github.com/Beliavsky/Fortran-packages-list
+author   : Beliavsky, Norwid Behrnd
+license  : MIT
+last edit: [2024-04-26 Fri]
+purpose  : report projects that can be built with the Fortran Package Manager
+"""
+
+import argparse
+import os
+# import re
+import time
+# from urllib3.util import Retry
+
+# import requests
+# from requests.adapters import HTTPAdapter
+
+os.environ["PYTHONIOENCODING"] = "utf-8"
+
+
+def get_args():
+    """get the command-line arguments"""
+
+    parser = argparse.ArgumentParser(
+        description="""List projects, organized by topic, that can be built with
+        the Fortran Package Manager.  For this, file README.md of project
+        'Directory of Fortran codes on GitHub' curated by Beliavsky et al. (see
+        https://github.com/Beliavsky/Fortran-code-on-GitHub) is processed as
+        input for this script.""",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+
+    parser.add_argument(
+        "file",
+        help="said README.md file",
+        metavar="FILE",
+        type=argparse.FileType("rt", encoding="utf-8"),
+        default=None,
+    )
+
+    parser.add_argument(
+        "-d",
+        "--debug",
+        help="activate the scripts internal debugger",
+        action="store_true",
+    )
+
+    parser.add_argument(
+        "-t",
+        "--test",
+        help="constrain a test run to 125 lines output",
+        action="store_true",
+    )
+
+    return parser.parse_args()
+
+
+#def check_url_exists(url, max_redirects=20, max_retries=5):
+#    """check accessibility of queried url"""
+
+#    session = requests.Session()
+#    retries = Retry(
+#        total=max_retries, backoff_factor=1.1, status_forcelist=[500, 502, 503, 504]
+#    )
+#    session.mount("https://", HTTPAdapter(max_retries=retries))
+
+#    try:
+#        # Make a HEAD request to get headers and avoid downloading the content
+#        # https://stackoverflow.com/questions/46016004/how-to-handle-timeout-error-in-request-headurl
+#        response = requests.head(url, allow_redirects=True, timeout=5)
+#        # Check if the response status code is in the range of 200-299 (success)
+#        if response.status_code in range(200, 300):
+#            return True, response.status_code
+#        else:
+#            return False, response.status_code
+#    except requests.RequestException as e:
+#        # Handle exceptions like network errors, invalid URLs, etc.
+#        return False, str(e)
+
+
+def file_reader(infile="", debug=False, test=False):
+    """iterate on the input file till reaching the threshold"""
+
+    max_lines = 300 if test else 10**6  # allow a constrained test run
+    raw_data = [line.strip() for line in infile]
+    array_prior_test_condition = len(raw_data)
+
+    if test:
+        raw_data = raw_data[:max_lines]
+    array_after_test_condition = len(raw_data)
+
+    if debug:
+        print("lines in raw_data to process:")
+        print(f"array_prior_test_condition: {array_prior_test_condition}")
+        print(f"array_after_test_condition: {array_after_test_condition}")
+
+    return raw_data
+
+
+#def checker(text, debug=False, i=1):
+#    """extract the address, report if fpm.toml file is present"""
+#    if text.startswith("*") or text.startswith("##"):  # category marker
+#        print(text)
+
+#    # text in parentheses after first after first set of brackets
+#    match = re.search(r"\[.*?\]\((.*?)\)", text)
+#    # Extract the match, if it exists
+#    extracted_address = match.group(1) if match else None
+#    if extracted_address:
+#        if debug:
+#            print("\n", i)
+#            print(text.strip())
+#            print(f"url: {extracted_address}")
+#        fpm_link = extracted_address + "/blob/master/fpm.toml"
+#        exists, status_or_error = check_url_exists(fpm_link)
+#        if exists:
+#            try:
+#                print(text)
+#            except UnicodeEncodeError as e:
+#                # Handle the error: for example, print a placeholder text or
+#                # encode the text in 'utf-8' and print
+#                print("An encoding error occurred: ", e)
+#            if debug:
+#                print(fpm_link)
+
+
+def triage_lines(raw_data, debug=False):
+    """identify lines with addresses to check on GitHub for a fpm.toml file"""
+    previous_section_title = ""
+    intermediate_register = []
+
+    for i, line in enumerate(raw_data):
+        # lines with less work ahead:
+        if line.startswith("## Fortran code on GitHub"):
+            print("".join([line, "\n"]))
+        if line.startswith("* ["):
+            print("".join([line, "\n"]))
+
+        # lines with more work ahead
+        # projects eventually to visit on GitHub
+        if line.startswith("["):
+            intermediate_register.append(line)
+
+        # sections like "Art and Music", "Astronomy and Astrophysics", etc.
+        if line.startswith("##"):
+            if line.startswith("## Fortran code on GitHub") is False:
+                if intermediate_register:
+                    print("".join([previous_section_title, "\n"]))
+
+                    if debug:
+                        print(f"{len(intermediate_register)} entries to check")
+
+                    for entry in intermediate_register:
+                        print("".join([entry, "\n"]))
+                    intermediate_register = []
+                previous_section_title = line
+
+        # Equally report a section if a line about a project happens to be the
+        # ultimate line of the raw_data read:
+        if i == len(raw_data) - 1:
+            print("".join([previous_section_title, "\n"]))
+
+            if debug:
+                print(f"{len(intermediate_register)} entries to check")
+
+            for entry in intermediate_register:
+                print("".join([entry, "\n"]))
+
+
+
+def main():
+    """join the functionalities"""
+
+    args = get_args()
+    infile = args.file
+    debugger_level = args.debug
+    test_level = args.test
+
+    t0 = time.time()
+    raw_data = file_reader(infile, debugger_level, test_level)
+    triage_lines(raw_data, debugger_level)
+    print(f"time elapsed (s): {(time.time() - t0):.2f}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
For an easier repeated use of the script, the script now additionally uses the `argparse` module of Python's standard library.  This equally provides the user a brief documentation (accessible by `-h` or `--help`) how to use the script.

I presume the internal variable `debug` was defined to allow a more verbose output, this now is equally accessible from the CLI as an optional parameter (`-d`), as well one optional which constrains the output to 125 lines only (to test if the script works "at all") by `-t`.